### PR TITLE
Fix: Subsite navigation

### DIFF
--- a/templates/subsites/subsite-navigation.html.twig
+++ b/templates/subsites/subsite-navigation.html.twig
@@ -46,12 +46,14 @@
           item.in_active_trail ? 'menu-item--active-trail',
         ]
       %}
+      {% if item.url %}
       <li{{ item.attributes.addClass(classes) }}>
         {{ link(item.title, item.url) }}
         {% if item.below %}
           {{ subsite_navigation.menu_links(item.below, attributes, menu_level + 1) }}
         {% endif %}
       </li>
+      {% endif %}
     {% endfor %}
     </ul>
   {% endif %}


### PR DESCRIPTION
The Subsite navigation is causing WSOD (White screen of death) while attempting to prepare links for unpublished grandchild pages.  This is happening particularly when under-construction Subsite pages are accessed through Preview links.

This may be a temporary fix.  It maybe that the root cause lies in the localgov_subsites module.  Further troubleshooting necessary.