### PR TITLE
Feature/remove h3 on homepage cta boxes

### DIFF
--- a/assets/scss/lib/partials/_box-links.scss
+++ b/assets/scss/lib/partials/_box-links.scss
@@ -37,6 +37,11 @@
           padding: 0;
         }
 
+        h2 { // clear off defaults
+          margin: 0;
+          padding: 0;
+        }
+
         @include media-breakpoint-up(sm) {
           position: relative;
           width: calc(25% - 0.46875rem);

--- a/localgov_base_croydon.theme
+++ b/localgov_base_croydon.theme
@@ -49,3 +49,19 @@ function localgov_base_croydon_preprocess_node__localgov_guides_page__full(&$var
 function localgov_base_croydon_preprocess_localgov_geo__cds_plain_address(&$variables) {
   $variables['content']['label'] = NULL;
 }
+
+/**
+ * Implements hook_preprocess_paragraph().
+ *
+ * Changes:
+ * Adds a variable to determinse if the box links are
+ * on the home page
+ *
+ * @see localgov_base_croydon_preprocess_paragraph__localgov_box_link()
+ */
+function localgov_base_croydon_preprocess_paragraph__localgov_box_link(&$variables) {
+  $paragraph = $variables['paragraph'];
+  if ($paragraph->bundle() === 'localgov_box_link') {
+    $variables['is_front'] = \Drupal::service('path.matcher')->isFrontPage();
+   }
+}

--- a/templates/paragraph/paragraph--localgov-box-link.html.twig
+++ b/templates/paragraph/paragraph--localgov-box-link.html.twig
@@ -1,0 +1,114 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{#
+  We are setting a variable here for the parent entity. We can then use that to
+  check what heading level is set in the parent
+  Using this, we can then set our heading to be one level below the parent's heading.
+#}
+{% set parent = paragraph._referringItem.parent.parent.entity %}
+{% set parent_heading_level = parent.localgov_heading_level.value %}
+
+{#
+  On the Homepage the headings hierachy is
+  We are checking to see if these box link listings are on the
+  homepage. If they are, then we make the assumption that they are
+  immediately below the homepage's subsite banner which r
+  contains a h1
+#}
+{% if is_front %}
+  {% set parent_heading_level = 'h1' %}
+{% endif %}
+
+{% if parent_heading_level %}
+  {% if parent_heading_level == 'h1' %}
+  {% set heading_level = 'h2' %}
+  {% elseif parent_heading_level == 'h2' %}
+    {% set heading_level = 'h3' %}
+    {% elseif parent_heading_level == 'h3' %}
+      {% set heading_level = 'h4' %}
+      {% elseif parent_heading_level == 'h4' %}
+        {% set heading_level = 'h5' %}
+        {% elseif parent_heading_level == 'h5' %}
+          {% set heading_level = 'h6' %}
+        {% else %}
+  {% endif %}
+  {% else %}
+    {# If parent_heading_level is not set, default to H2 #}
+    {% set heading_level = 'h2' %}
+{% endif %}
+
+{%
+  set classes = [
+    'box-link',
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+  ]
+%}
+
+{% if not localgov_base_remove_css %}
+  {{ attach_library('localgov_base/box-links') }}
+{% endif %}
+
+<article{{ attributes.addClass(classes) }}>
+
+  {% if paragraph.localgov_image.value %}
+    <div class="box-link__image">
+      {{ content.localgov_image }}
+    </div>
+  {% endif %}
+
+  <{{ heading_level }} class="box-link__title">
+    <a class="box-link__link" href="{{ localgov_link.url }}"
+      {% if localgov_link.open_in_new_window %}
+      target="_blank" rel="external noopener noreferrer">
+      <span class="visually-hidden">{{ '(opens in a new window)'|t }}</span>
+      {% else %}
+        >
+      {% endif %}
+        {{ localgov_link.title }}
+    </a>
+  </{{heading_level }}>
+
+  {{ content|without('localgov_link', 'localgov_image') }}
+</article>


### PR DESCRIPTION
Hi @cjstevens78 
My approach with this was to override the localgov_base template file by adding own. In our template. I made the assumption (based on the publishing site's current design) that if these box links CTA are on the homepage, then they're going to be placed underneath the title 'Welcome to Croydon' which is a H1. I added a preprocess function to determine if the box link is on the homepage and amended the templates parent_heading_level algorithm