### PR TITLE
Adjusted email header logo width

### DIFF
--- a/templates/email/webform-email-message-html.html.twig
+++ b/templates/email/webform-email-message-html.html.twig
@@ -16,9 +16,9 @@
 		<title>{{ subject }}</title>
 	</head>
 	<body>
-		<div id="header" style="background-color: #880088; padding: 10px 0px 0px 10px;">
+		<div id="header" style="background-color: #880088; padding: 10px 10px 10px 10px;">
 			<div id="container" style="padding-left:50px">
-				<img src="https://www.croydon.gov.uk/themes/contrib/localgov_base_croydon/logo.png" alt="{{ 'Croydon Council Forms Site Logo'|t }}" width="154px" height="56px">
+				<img src="https://www.croydon.gov.uk/themes/contrib/localgov_base_croydon/logo.png" alt="{{ 'Croydon Council Forms Site Logo'|t }}" width="182px" height="52px">
 			</div>
 		</div>
 		<div id="body" style="padding-left:50px">


### PR DESCRIPTION
The 'Croydon' logo needed resizing in the webform email template because it was a bit squashed.