### PR TITLE
Additional padding to the header region of  top of webform email templates header

### DIFF
--- a/templates/email/webform-email-message-html.html.twig
+++ b/templates/email/webform-email-message-html.html.twig
@@ -16,7 +16,7 @@
 		<title>{{ subject }}</title>
 	</head>
 	<body>
-		<div id="header" style="background-color: #880088; padding: 10px 10px 10px 10px;">
+		<div id="header" style="background-color: #880088; padding: 20px 10px 10px 10px;">
 			<div id="container" style="padding-left:50px">
 				<img src="https://www.croydon.gov.uk/themes/contrib/localgov_base_croydon/logo.png" alt="{{ 'Croydon Council Forms Site Logo'|t }}" width="182px" height="52px">
 			</div>


### PR DESCRIPTION
I needed to add  padding to the top so that the logo has  an equal amount of space above and below it.