### PR TITLE
Updated the My Account link URL

### DIFF
--- a/templates/layout/page--design-system-page.html.twig
+++ b/templates/layout/page--design-system-page.html.twig
@@ -57,7 +57,7 @@
         <nav aria-label="Footer Navigation">
           <ul>
             <li>
-              <a href="https://my.croydon.gov.uk">My Account</a>
+              <a href="https://www.croydon.gov.uk/council-and-elections/communications/my-account-services">My Account</a>
             </li>
             <li>
               <a href="https://www.croydon.gov.uk/aboutus">About us</a>

--- a/templates/layout/page--moderngov-template.html.twig
+++ b/templates/layout/page--moderngov-template.html.twig
@@ -59,7 +59,7 @@
           </div>
         </div>
       </div>
-     
+
       <div class="lgd-footer__post-footer">
         <div class="lgd-container">
           <div class="lgd-row">
@@ -71,7 +71,7 @@
               <nav aria-label="Footer Navigation">
                 <ul>
                   <li>
-                    <a href="https://my.croydon.gov.uk">My Account</a>
+                    <a href="https://www.croydon.gov.uk/council-and-elections/communications/my-account-services">My Account</a>
                   </li>
                   <li>
                     <a href="https://www.croydon.gov.uk/aboutus">About us</a>

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -12,7 +12,7 @@
         <nav aria-label="Footer Navigation">
           <ul>
             <li>
-              <a href="https://my.croydon.gov.uk">My Account</a>
+              <a href="https://www.croydon.gov.uk/council-and-elections/communications/my-account-services">My Account</a>
             </li>
             <li>
               <a href="https://www.croydon.gov.uk/aboutus">About us</a>


### PR DESCRIPTION
The 'My Account' link needed to be updated so that it points to https://www.croydon.gov.uk/council-and-elections/communications/my-account-services