### PR TITLE
Capitalise the post code used in channel search results

### DIFF
--- a/templates/views/views-view--localgov-directory-channel.html.twig
+++ b/templates/views/views-view--localgov-directory-channel.html.twig
@@ -49,7 +49,7 @@
     <div class="view-header">
       {{ header }}
         {% if search_string and display_id == 'node_embed' %}
-          <span class="directory-search-string">{{ search_string|capitalize }}</span>
+          <span class="directory-search-string">{{ search_string|upper }}</span>
         {% endif %}
     </div>
   {% endif %}


### PR DESCRIPTION
## What does this change?
Capitalises the post code shown in directory channel search result summary

## How to test
Navigate to a directory channel page and view  results summary shown below the map 
- eg. 1 - 4 of 4 results matching **CR0 0SE**
