### PR TITLE
Feature/capitalise or title case channel directory search result summary

### DIFF
--- a/templates/views/views-view--localgov-directory-channel.html.twig
+++ b/templates/views/views-view--localgov-directory-channel.html.twig
@@ -39,6 +39,12 @@
     dom_id ? 'js-view-dom-id-' ~ dom_id,
   ]
 %}
+
+{# UK postcode regex  https://github.com/stemount/gov-uk-official-postcode-regex-helper #}
+{% set post_code_regex =
+  '/^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A- Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z])))) [0-9][A-Za-z]{2})$/'
+
+%}
 <div{{ attributes.addClass(classes) }}>
   {{ title_prefix }}
   {% if title %}
@@ -52,7 +58,7 @@
           {# If the search string starts with two letters and then a digit,
            then we assume its a uk postcode and we want to display it in
            uppercase. Otherwise we want to display it in title case. #}
-          {% if search_string matches '/^[A-Za-z]{2}[0-9]/' %}
+          {% if search_string matches post_code_regex %}
             <span class="directory-search-string">{{ search_string|upper }}</span>
           {% else %}
           {# We assume its a name, display the name in title case #}

--- a/templates/views/views-view--localgov-directory-channel.html.twig
+++ b/templates/views/views-view--localgov-directory-channel.html.twig
@@ -49,7 +49,15 @@
     <div class="view-header">
       {{ header }}
         {% if search_string and display_id == 'node_embed' %}
-          <span class="directory-search-string">{{ search_string|upper }}</span>
+          {# If the search string starts with two letters and then a digit,
+           then we assume its a uk postcode and we want to display it in
+           uppercase. Otherwise we want to display it in title case. #}
+          {% if search_string matches '/^[A-Za-z]{2}[0-9]/' %}
+            <span class="directory-search-string">{{ search_string|upper }}</span>
+          {% else %}
+          {# We assume its a name, display the name in title case #}
+            <span class="directory-search-string">{{ search_string|title }}</span>
+          {% endif %}
         {% endif %}
     </div>
   {% endif %}

--- a/templates/views/views-view--localgov-directory-channel.html.twig
+++ b/templates/views/views-view--localgov-directory-channel.html.twig
@@ -40,10 +40,9 @@
   ]
 %}
 
-{# UK postcode regex  https://github.com/stemount/gov-uk-official-postcode-regex-helper #}
+{# UK postcode regex https://stackoverflow.com/questions/164979/regex-for-matching-uk-postcodes#}
 {% set post_code_regex =
-  '/^([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A- Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9]?[A-Za-z])))) [0-9][A-Za-z]{2})$/'
-
+  '/^([A-Za-z][A-Ha-hJ-Yj-y]?[0-9][A-Za-z0-9]? ?[0-9][A-Za-z]{2}|[Gg][Ii][Rr] ?0[Aa]{2})$/'
 %}
 <div{{ attributes.addClass(classes) }}>
   {{ title_prefix }}


### PR DESCRIPTION
What does this change?
This adds a regex pattern as a variable called post_code_regex to the directory channel template so that the result summary correctly formats the search string as postcode or road name.

How to test
- Navigate to a directory [channel page](https://lbc-app-w-localgov-corpwebsite-dev3.azurewebsites.net/housing/information-council-tenants/your-tenancy-and-rent/find-your-housing-and-income-officers) 
- Search by post code  e.g 'cr0 3pu'
- Verify that the result summary  capitalises the  post code e.g 'CR0 3PU'
- Search by road name e.g  'homestead way'
- Verify that the result summary 'Title cases' the road name e.g 'Homestead Way'


