### PR TITLE
Makes the latest version menu item red

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -119,10 +119,20 @@
             $(".lgd-guide-nav__content").css("display", "block");
           } else {
             $(".lgd-guide-nav").removeClass("hidden");
-            $(".lgd-guide-nav__content").css();
+            $(".lgd-guide-nav__content").css("display", "block");
           }
         }).resize();
 
+        // Highlight the "Latest version" menu item in the secondary menu.
+        // This will set the background color of the link to red.
+        $('li').each(function() {
+          var link = $(this).find('a');
+          if (link.length && link.text().trim() === 'Latest version') {
+            // This list item contains the link with the text "Latest version"
+            // Set the anchor tag's background to red
+            link.css('background-color', 'red');
+          }
+        });
       })
     }
   }

--- a/js/main.js
+++ b/js/main.js
@@ -125,7 +125,7 @@
 
         // Highlight the "Latest version" menu item in the secondary menu.
         // This will set the background color of the link to red.
-        $('li').each(function() {
+        $('.tabs li').each(function() {
           var link = $(this).find('a');
           if (link.length && link.text().trim() === 'Latest version') {
             // This list item contains the link with the text "Latest version"


### PR DESCRIPTION

## What does this change?
This adds a 'Red' background to the revisions menu link 

## How to test

- Whilst logged in as a content designer
- Navigate to the content admin pages  - /admin/content
- Click on the 'Review' tabbed menu
- Choose a node and click on the 'Edit' menu in the operation column
- Verify that the 'Latest version' menu item has a red background


## Images
![image](https://github.com/user-attachments/assets/b01ffb25-2768-42d5-bd1a-9fdc356cbc83)

