### PR TITLE
Restores content menus expand or collapse toggle functionality

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -119,7 +119,7 @@
             $(".lgd-guide-nav__content").css("display", "block");
           } else {
             $(".lgd-guide-nav").removeClass("hidden");
-            $(".lgd-guide-nav__content").css("display", "block");
+            $(".lgd-guide-nav__content").css("display", "none");
           }
         }).resize();
 


### PR DESCRIPTION
## What does this change?
- Restores content menus expand or collapse toggle functionality on mobile devices

## How to test
- Navigate to /rubbish-and-recycling/bins/rubbish-bins on mobile device
- Verify that the content menu can be expanded and collapsed

## How can we measure success?
- Users are able to expand or collapse  the menu

