### PR TITLE
Shortens labels for date field elements

### DIFF
--- a/assets/scss/lib/partials/_forms.scss
+++ b/assets/scss/lib/partials/_forms.scss
@@ -83,6 +83,7 @@
 
 .form-item {
   &-localgov-forms-date { // date specific styling
+    gap: 1.125rem;
 
     .container-inline {
       @extend .row;
@@ -895,4 +896,11 @@ main.col-sm-8 .webform-type-fieldset legend,
 // reset search input border in masthead
 .lgd-header .lgd-region--search input {
   border: .06rem solid $checkbox-outline !important;
+}
+
+// Adds a gap between the date fields in the localgov-forms-date class
+.localgov-forms-date {
+  // display: flex;
+  // flex-wrap: wrap;
+  gap: 1.125rem;
 }

--- a/assets/scss/lib/partials/_forms.scss
+++ b/assets/scss/lib/partials/_forms.scss
@@ -83,7 +83,6 @@
 
 .form-item {
   &-localgov-forms-date { // date specific styling
-    gap: 1.125rem;
 
     .container-inline {
       @extend .row;
@@ -900,7 +899,5 @@ main.col-sm-8 .webform-type-fieldset legend,
 
 // Adds a gap between the date fields in the localgov-forms-date class
 .localgov-forms-date {
-  // display: flex;
-  // flex-wrap: wrap;
   gap: 1.125rem;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -133,6 +133,12 @@
             link.css('background-color', 'red');
           }
         });
+
+        // Add a visually hidden class to the label of localgov forms
+        // date fields to hide the label visually but keep it accessible
+        // for screen readers.
+        $('.localgov-forms-date label').addClass('visually-hidden');
+
       })
     }
   }

--- a/js/main.js
+++ b/js/main.js
@@ -133,12 +133,6 @@
             link.css('background-color', 'red');
           }
         });
-
-        // Add a visually hidden class to the label of localgov forms
-        // date fields to hide the label visually but keep it accessible
-        // for screen readers.
-        $('.localgov-forms-date label').addClass('visually-hidden');
-
       })
     }
   }

--- a/localgov_base_croydon.theme
+++ b/localgov_base_croydon.theme
@@ -193,8 +193,8 @@ function localgov_base_croydon_preprocess_node__cds_tenancy_office_dir_page__cds
  * Implements hook_preprocess_block().
  *
  * Hides the Table of Contents (TOC) block on specific Publication outline pages.
- * 
- * This function checks if the current page belongs to a Book hierarchy and 
+ *
+ * This function checks if the current page belongs to a Book hierarchy and
  * removes the block if the node is either a parent (that has child pages) or a child
  */
 function localgov_base_croydon_preprocess_block(array &$variables) {
@@ -240,22 +240,22 @@ function localgov_base_croydon_preprocess_field(array &$variables, string $hook)
 function localgov_base_croydon_preprocess_node__localgov_subsites_page__full(&$variables) {
   $node = $variables['node'];
   $has_banner_meaningful_content = FALSE;
-  
+
   if ($node->hasField('localgov_subsites_banner') && !$node->get('localgov_subsites_banner')->isEmpty()) {
     $first_item = $node->get('localgov_subsites_banner')->first();
-    
+
     if ($first_item) {
       // Try to load the paragraph entity
       $banner_paragraph = $first_item->entity;
       if (!$banner_paragraph && $first_item->target_id) {
         $banner_paragraph = \Drupal\paragraphs\Entity\Paragraph::load($first_item->target_id);
       }
-      
+
       if ($banner_paragraph && $banner_paragraph instanceof \Drupal\paragraphs\ParagraphInterface) {
         $banner_image_has_content = FALSE;
         $banner_title_has_content = FALSE;
         $banner_text_has_content = FALSE;
-        
+
         // Image check
         if ($banner_paragraph->hasField('localgov_image') && !$banner_paragraph->get('localgov_image')->isEmpty() && $banner_paragraph->get('localgov_image')->target_id) {
           $file = \Drupal\file\Entity\File::load($banner_paragraph->get('localgov_image')->target_id);
@@ -263,7 +263,7 @@ function localgov_base_croydon_preprocess_node__localgov_subsites_page__full(&$v
             $banner_image_has_content = TRUE;
           }
         }
-        
+
         // Title check
         if ($banner_paragraph->hasField('localgov_title') && !$banner_paragraph->get('localgov_title')->isEmpty()) {
           $title_value = $banner_paragraph->get('localgov_title')->value;
@@ -272,7 +272,7 @@ function localgov_base_croydon_preprocess_node__localgov_subsites_page__full(&$v
             $banner_title_has_content = TRUE;
           }
         }
-        
+
         // Text check
         if ($banner_paragraph->hasField('localgov_subsites_banner_text') && !$banner_paragraph->get('localgov_subsites_banner_text')->isEmpty()) {
           $text_value = $banner_paragraph->get('localgov_subsites_banner_text')->value;
@@ -284,11 +284,33 @@ function localgov_base_croydon_preprocess_node__localgov_subsites_page__full(&$v
             $banner_text_has_content = TRUE;
           }
         }
-        
+
         $has_banner_meaningful_content = $banner_image_has_content || $banner_title_has_content || $banner_text_has_content;
       }
     }
   }
-  
+
   $variables['has_banner_meaningful_content'] = $has_banner_meaningful_content;
+}
+
+/**
+ * Implements hook_preprocess_form_element_label() for localgov date fields.
+ * This function rewrites the label for date fields in LocalGov forms.
+ */
+function localgov_base_croydon_preprocess_form_element_label(&$variables) {
+  // Only proceed if the 'for' attribute exists.
+  if (!empty($variables['attributes']['for'])) {
+    $for = $variables['attributes']['for'];
+    $suffix_map = [
+      '-day' => t('Day'),
+      '-month' => t('Month'),
+      '-year' => t('Year'),
+    ];
+    foreach ($suffix_map as $suffix => $label) {
+      if (str_contains($for, $suffix)) {
+        $variables['title']['#markup'] = $label;
+        break;
+      }
+    }
+  }
 }

--- a/localgov_base_croydon.theme
+++ b/localgov_base_croydon.theme
@@ -295,7 +295,8 @@ function localgov_base_croydon_preprocess_node__localgov_subsites_page__full(&$v
 
 /**
  * Implements hook_preprocess_form_element_label() for localgov date fields.
- * This function rewrites the label for date fields in LocalGov forms.
+ * This function rewrites the label for date fields in LocalGov forms
+ * date field parts.
  */
 function localgov_base_croydon_preprocess_form_element_label(&$variables) {
   // Only proceed if the 'for' attribute exists.


### PR DESCRIPTION
## What does this change?
- Adds a theme preprocess function that shortens date part labels to Day Month Year

## How to test
- Navigate to a localgov forms date webform element e.g. [Change of vehicle temporary cover request](https://lbc-app-w-localgov-formsite-dev1.azurewebsites.net/form/temporary-cover-permit-request?page=2)
- Verify that the date input fields have a label above them entitled - Day Month  Year

