### PR TITLE
Localgov Forms Date field styling improvements 

### DIFF
--- a/assets/scss/lib/partials/_forms.scss
+++ b/assets/scss/lib/partials/_forms.scss
@@ -81,10 +81,23 @@
   }
 }
 
+.js-form-type-localgov-forms-dob .container-inline,
 .form-item {
   &-localgov-forms-date { // date specific styling
+    display: flex;
+    flex-wrap: nowrap;
 
     .container-inline {
+      display: flex;
+      flex-wrap: nowrap;
+      margin-right: -0.938rem;
+      margin-left: -0.938rem;
+
+      @include media-breakpoint-up(md) {
+        max-width: 33.333%; // Shortens the length of date input parts
+      }
+
+
       @extend .row;
 
       .form-item {
@@ -831,7 +844,6 @@ span.facet-item__count {
 }
 
 /* Custom Date of Birth Styling */
-
 .form-item-lgd-date-of-birth .container-inline,
 .form-item-lgd-date-of-birth-desc-after .container-inline {
   display: flex;
@@ -897,7 +909,34 @@ main.col-sm-8 .webform-type-fieldset legend,
   border: .06rem solid $checkbox-outline !important;
 }
 
-// Adds a gap between the date fields in the localgov-forms-date class
-.localgov-forms-date {
+
+/* Custom Localgov Forms Date Styling */
+
+@media screen and (min-width: 64rem) {
+  .localgov-forms-date div[class*="-day"],
+  .localgov-forms-date div[class*="-month"] {
+    max-width: 6%;
+    margin-right: 1.5rem;
+  }
+}
+
+.localgov-forms-date.form-item-localgov-forms-date-day,
+.localgov-forms-date.form-item-localgov-forms-date-month,
+.localgov-forms-date.form-item-localgov-forms-date-year,
+.form-item-localgov-forms-date-day,
+.form-item-localgov-forms-date-month,
+.form-item-localgov-forms-date-year {
+  margin-right: 0 !important;
+  padding-right: 0 !important;
+}
+
+/* Custom Localgov Forms Date of Birth Styling */
+.js-form-type-localgov-forms-dob .container-inline {
+  display: flex;
+  flex-wrap: nowrap;
   gap: 1.125rem;
+
+  @include media-breakpoint-up(md) {
+    max-width: 33.333%; // Shortens the length of date input parts
+  }
 }

--- a/assets/scss/lib/partials/_forms.scss
+++ b/assets/scss/lib/partials/_forms.scss
@@ -93,6 +93,7 @@
       flex-wrap: nowrap;
       margin-right: -0.938rem;
       margin-left: -0.938rem;
+      width: 100%;
 
       @include media-breakpoint-up(md) {
         max-width: 33.333%; // Shortens the length of date input parts

--- a/assets/scss/lib/partials/_forms.scss
+++ b/assets/scss/lib/partials/_forms.scss
@@ -86,6 +86,7 @@
   &-localgov-forms-date { // date specific styling
     display: flex;
     flex-wrap: nowrap;
+    flex-direction: column;
 
     .container-inline {
       display: flex;


### PR DESCRIPTION
## What does this change?
 - Shortens the length of  Localgov Forms  Date input  fields when viewed on desktop
 - Prevents wrapping onto next line for Localgov Forms Date input fields 

## How to test
- Navigate to a localgov forms date webform element e.g. [Element Label Test](https://lbc-app-w-localgov-formsite-dev1.azurewebsites.net/form/element-label-test#no-back)
- Verify that the date input fields have a label above them entitled - Day Month Year
- Verify that the date part input fields are short in length. e.g they dont take up the width of the page , but are long enough to hold the DD  MM and YYYY values entered into them.

