### PR TITLE
Feature/highlight unpublished guide pages

### DIFF
--- a/css/components/guide-nav.css
+++ b/css/components/guide-nav.css
@@ -27,20 +27,21 @@
 }
 
 a.unpublished-guide-link  {
-  background-color: #FFCC33;
-  color: white;
+  background-color:  var(--color-yellow);
+  color: var(--color-white);
   padding: 4px;
   margin: 2px;
   display: inline-block;
   text-decoration: none;
 }
+
 a.unpublished-guide-link:after {
     content: 'Unpublished';
     display: inline-block;
     margin: .25em;
     padding-left: .25em;
     padding-right: .25em;
-    color: white;
-    background-color: black;
+    color:  var(--color-white);
+    background-color:  var(--color-black);
     font-weight: bold;
 }

--- a/css/components/guide-nav.css
+++ b/css/components/guide-nav.css
@@ -25,3 +25,22 @@
 		padding-left: 0.6rem;
 	}
 }
+
+a.unpublished-guide-link  {
+  background-color: #FFCC33;
+  color: white;
+  padding: 4px;
+  margin: 2px;
+  display: inline-block;
+  text-decoration: none;
+}
+a.unpublished-guide-link:after {
+    content: 'Unpublished';
+    display: inline-block;
+    margin: .25em;
+    padding-left: .25em;
+    padding-right: .25em;
+    color: white;
+    background-color: black;
+    font-weight: bold;
+}


### PR DESCRIPTION
## What does this change?
This change provides styling that highlights and labels unpublished guide page links within a navigational block to logged in users 

## How to test
- Whilst logged in as a content designer
- Navigate to a guide page's edit page
- Check if there are any links that have a yellow background and are labelled as 'Unpublished' in the navigation block
- Logout 
- Navigate back to the example guide page URL and verify that the link is not highlighted

Available to check [here](https://lbc-app-w-localgov-corpwebsite-dev5.azurewebsites.net/benefits/financial-hardship/dhp-arrears)

