### PR TITLE
Feature/highlight unpublished guide pages version 2

### DIFF
--- a/css/components/guide-nav.css
+++ b/css/components/guide-nav.css
@@ -25,6 +25,8 @@
 		padding-left: 0.6rem;
 	}
 }
+
+[data-drupal-is-unpublished],
 a[data-drupal-is-unpublished] {
   background-color:  var(--color-yellow);
   color: var(--color-white);
@@ -34,6 +36,7 @@ a[data-drupal-is-unpublished] {
   text-decoration: none;
 }
 
+[data-drupal-is-unpublished][aria-current="page"]:after,
 a[data-drupal-is-unpublished]:after {
     content: 'Unpublished';
     display: inline-block;

--- a/css/components/guide-nav.css
+++ b/css/components/guide-nav.css
@@ -25,3 +25,22 @@
 		padding-left: 0.6rem;
 	}
 }
+a[data-drupal-is-unpublished] {
+  background-color:  var(--color-yellow);
+  color: var(--color-white);
+  padding: 4px;
+  margin: 2px;
+  display: inline-block;
+  text-decoration: none;
+}
+
+a[data-drupal-is-unpublished]:after {
+    content: 'Unpublished';
+    display: inline-block;
+    margin: .25em;
+    padding-left: .25em;
+    padding-right: .25em;
+    color:  var(--color-white);
+    background-color:  var(--color-black);
+    font-weight: bold;
+}

--- a/templates/block/guides-contents-block.html.twig
+++ b/templates/block/guides-contents-block.html.twig
@@ -23,9 +23,9 @@
     <{{ list_type }} class="lgd-guide-nav__list">
       {% for link in links %}
         {% if link.url.options.attributes.class == 'active' %}
-          <li class="lgd-guide-nav__list-item lgd-guide-nav__list-item--active" aria-current="page">{{ link.text }}</li>
+          <li class="lgd-guide-nav__list-item lgd-guide-nav__list-item--active" {{ link.url.options.attributes.('data-drupal-is-unpublished') is not empty ? 'data-drupal-is-unpublished' : '' }} aria-current="page">{{ link.text }}</li>
           {% else %}
-            <li class="lgd-guide-nav__list-item">{{ link }}</li>
+          <li class="lgd-guide-nav__list-item" {{ link.url.options.attributes.('data-drupal-is-unpublished') is not empty ? 'data-drupal-is-unpublished' : '' }}>{{ link }}</li>
         {% endif %}
       {% endfor %}
     </{{ list_type }}>


### PR DESCRIPTION
What does this change?
This change uses the data attribute  [data-drupal-is-unpublished]  as a css selector  in order to provide styling that highlights and labels unpublished guide page links within a navigational block to logged in users

How to test
Whilst logged in as a content designer
Navigate to a guide page's edit page
Check if there are any links that have a yellow background and are labelled as 'Unpublished' in the navigation block
Logout
Navigate back to the example guide page URL and verify that the link is not highlighted
Available to check [here](https://lbc-app-w-localgov-corpwebsite-dev5.azurewebsites.net/benefits/financial-hardship/dhp-arrears)