### PR TITLE
Restored bullet point and font colour to highlighted guide page link

### DIFF
--- a/css/components/guide-nav.css
+++ b/css/components/guide-nav.css
@@ -29,21 +29,17 @@
 [data-drupal-is-unpublished],
 a[data-drupal-is-unpublished] {
   background-color:  var(--color-yellow);
-  color: var(--color-white);
   padding: 4px;
   margin: 2px;
-  display: inline-block;
   text-decoration: none;
 }
 
 [data-drupal-is-unpublished][aria-current="page"]:after,
 a[data-drupal-is-unpublished]:after {
     content: 'Unpublished';
-    display: inline-block;
     margin: .25em;
     padding-left: .25em;
     padding-right: .25em;
-    color:  var(--color-white);
     background-color:  var(--color-black);
     font-weight: bold;
 }


### PR DESCRIPTION
What does this change?
This change restore missing bullet style and font colour to the highlighted guide page links.

How to test
Whilst logged in as a content designer
Navigate to a guide page's edit page
Check if there are any links that have a yellow background and are labelled as 'Unpublished' in the navigation block
Logout
Navigate back to the example guide page URL and verify that the link is not highlighted
Available to check [here](https://lbc-app-w-localgov-corpwebsite-dev5.azurewebsites.net/benefits/financial-hardship/dhp-arrears)