### PR TITLE
Changed repository for localgov_base to drupal/localgov_base

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,6 @@
     "homepage": "https://github.com/localgovdrupal/localgov_base_croydon",
     "license": "GPL-2.0-or-later",
     "require": {
-        "localgovdrupal/localgov_base": "^1.1 || ^2.0"
+        "drupal/localgov_base": "^1.1 || ^2.0"
     }
 }


### PR DESCRIPTION
## What does this change?
This changes  the localgov_base code repository from localgovdrupal to drupal
