### PR TITLE
Feature/subsite extra menu fix

### DIFF
--- a/localgov_base_croydon.theme
+++ b/localgov_base_croydon.theme
@@ -143,6 +143,11 @@ function localgov_base_croydon_preprocess_html(array &$variables) {
   if ($node instanceof \Drupal\node\NodeInterface && (int) $node->id() === 7907) {
     $variables['attributes']['class'][] = 'page-how-contact-us';
   }
+
+  if ($node instanceof \Drupal\node\NodeInterface && (int) $node->id() === 7297) {
+    $variables['attributes']['class'][] = 'subsite-extra ';
+    $variables['attributes']['class'][] = 'subsite-extra--color-theme_a';
+  }
 }
 
 /**

--- a/localgov_base_croydon.theme
+++ b/localgov_base_croydon.theme
@@ -136,6 +136,7 @@ function localgov_base_croydon_audit_template_overrides(): array {
  * Implements hook_preprocess_html().
  *
  * Adds a unique body class for the "How to contact us" page.
+ * Adds a unique body class for the "Subsite extra" page.
  */
 function localgov_base_croydon_preprocess_html(array &$variables) {
   $node = \Drupal::routeMatch()->getParameter('node');
@@ -143,9 +144,9 @@ function localgov_base_croydon_preprocess_html(array &$variables) {
   if ($node instanceof \Drupal\node\NodeInterface && (int) $node->id() === 7907) {
     $variables['attributes']['class'][] = 'page-how-contact-us';
   }
-
+  // Add a unique body class for the "Subsite extra" page.
   if ($node instanceof \Drupal\node\NodeInterface && (int) $node->id() === 7297) {
-    $variables['attributes']['class'][] = 'subsite-extra ';
+    $variables['attributes']['class'][] = 'subsite-extra';
     $variables['attributes']['class'][] = 'subsite-extra--color-theme_a';
   }
 }


### PR DESCRIPTION
## What does this change?
This change adds the css classes subsite extra and subsite-extra--color-theme_a  to the body element of a subsite extra page nid 7297

## How to test
- Navigate to the  page /croydon-start-for-life on [DEV1](https://lbc-app-w-localgov-corpwebsite-dev1.azurewebsites.net/)
- Verify that a custom header is visible
- Verify that the custom header has as a horizontal menu

